### PR TITLE
fix: set startupProbeType labels, before Google Cloud does

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -207,9 +207,11 @@ resource "google_cloud_run_service" "api" {
         "autoscaling.knative.dev/maxScale"        = "8"
         "run.googleapis.com/cloudsql-instances"   = google_sql_database_instance.main.connection_name
         "run.googleapis.com/client-name"          = "terraform"
-        "run.googleapis.com/startupProbeType"     = "Default"
         "run.googleapis.com/vpc-access-egress"    = "all"
         "run.googleapis.com/vpc-access-connector" = google_vpc_access_connector.main.id
+      }
+      labels = {
+        "run.googleapis.com/startupProbeType" = "Default"
       }
     }
   }
@@ -245,6 +247,9 @@ resource "google_cloud_run_service" "fe" {
     metadata {
       annotations = {
         "autoscaling.knative.dev/maxScale" = "8"
+      }
+      labels = {
+        "run.googleapis.com/startupProbeType" = "Default"
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -207,9 +207,9 @@ resource "google_cloud_run_service" "api" {
         "autoscaling.knative.dev/maxScale"        = "8"
         "run.googleapis.com/cloudsql-instances"   = google_sql_database_instance.main.connection_name
         "run.googleapis.com/client-name"          = "terraform"
+        "run.googleapis.com/startupProbeType"     = "Default"
         "run.googleapis.com/vpc-access-egress"    = "all"
         "run.googleapis.com/vpc-access-connector" = google_vpc_access_connector.main.id
-
       }
     }
   }


### PR DESCRIPTION
* Please [see Google-internal chat thread here](https://chat.google.com/room/AAAAb5BaQlc/9a726xlQMJM).
* This is an attempt to fix some of the integration test failures seen in https://github.com/GoogleCloudPlatform/terraform-google-three-tier-web-app/pull/55.
* The `DefaultVerify` method is failing because Google Cloud mutates some resources created by the Terraform — after `terraform apply`.
* The mutation caused by Google Cloud can be seen in the logs from [these build logs](https://pantheon.corp.google.com/cloud-build/builds/3475f3af-67b7-49b6-af07-fd68848996a3;step=5?mods=pan_ng2&project=cloud-foundation-cicd) [look for the 2 `->`/arrows in the logs]:
```
... 
...   # module.three_tier_app.google_cloud_run_service.api will be updated in-place
...   ~ resource "google_cloud_run_service" "api" {
...         id                         = "locations/us-central1/namespaces/three-tier-app-cc0c/services/deployment-2-api"
...         name                       = "deployment-2-api"
...
...       ~ template {
...           ~ metadata {
...               ~ labels      = {
...                   - "run.googleapis.com/startupProbeType" = "Default" -> null
...                 }
... 
...   # module.three_tier_app.google_cloud_run_service.fe will be updated in-place
...   ~ resource "google_cloud_run_service" "fe" {
...         id                         = "locations/us-central1/namespaces/three-tier-app-cc0c/services/deployment-2-fe"
...         name                       = "deployment-2-fe"
Step #5 - "multiple-deploy": TestMultipleDeploy 2023-06-15T22:47:05Z command.go:185:         # (4 unchanged attributes hidden)
...
...       ~ template {
...           ~ metadata {
...               ~ labels      = {
...                   - "run.googleapis.com/startupProbeType" = "Default" -> null
...                 }
```
* Judging from the logs above, it looks like Google Cloud is adding a `run.googleapis.com/startupProbeType` label (with a value of `"Default"`).