### PR TITLE
chore: Migrate images from GCR to AR

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,9 +19,7 @@ data "google_project" "project" {
 }
 
 locals {
-  api_image = (var.database_type == "mysql"
-    ? "us-docker.pkg.dev/google-samples/containers/jss/three-tier-web-app-api:v0.0.1"
-    : "us-docker.pkg.dev/google-samples/containers/jss/three-tier-web-app-api-postgres:v0.0.1")
+  api_image = (var.database_type == "mysql" ? "us-docker.pkg.dev/google-samples/containers/jss/three-tier-web-app-api:v0.0.1" : "us-docker.pkg.dev/google-samples/containers/jss/three-tier-web-app-api-postgres:v0.0.1")
   fe_image  = "us-docker.pkg.dev/google-samples/containers/jss/three-tier-web-app-fe:v0.0.1"
 
   api_env_vars_postgresql = {


### PR DESCRIPTION
### Background
* We need to migrate away from Google Container Registry (GCR) and use Artifact Registry (AR) instead.
* This JSS (Jump Start Solution) currently deploys three different container images:
    * `gcr.io/sic-container-repo/todo-fe`
    * `gcr.io/sic-container-repo/todo-api`
    * `gcr.io/sic-container-repo/todo-api-postgres:latest`
* **Update:** As of Oct 2024, these `gcr.io` images are using AR under the hood.

### Changes in this pull-request
* I’ve pushed (copied over) each image to an Artifact Registry repo in the `google-samples` project.
    * `gcr.io/sic-container-repo/todo-fe` 
        * to `us-docker.pkg.dev/google-samples/containers/jss/three-tier-web-app-fe:v0.0.1`
    * `gcr.io/sic-container-repo/todo-api`
        * to `us-docker.pkg.dev/google-samples/containers/jss/three-tier-web-app-api:v0.0.1`
    * `gcr.io/sic-container-repo/todo-api-postgres:latest`
        * `us-docker.pkg.dev/google-samples/containers/jss/three-tier-web-app-api-postgres:v0.0.1`
* I don’t have access to the `sic-container-repo` project (so I couldn’t just migrate the gcr.io URLs to Artifact Registry.) Plus, other JSSs use the google-samples project for their images (e.g., [this image](https://github.com/GoogleCloudPlatform/terraform-genai-rag/blob/569e311a8fcbb044257dd1940fb9cd603b96cac6/variables.tf#L54)). **Update:** As of Oct 2024, I now have access to the `sic-container-repo` project and the gcr.io images are using AR under the hood.


### How to review
1. You’ll see that the integration tests are passing (in the GitHub checks below).
2. Optional: You can use `docker inspect` to extract the `RootFS.Layers` value and check that the hashes match:
```
docker inspect gcr.io/sic-container-repo/todo-fe
docker inspect  us-docker.pkg.dev/google-samples/containers/jss/three-tier-web-app-fe:v0.0.1
# Layers' sha256 hashes should be identical

docker inspect gcr.io/sic-container-repo/todo-api
docker inspect  us-docker.pkg.dev/google-samples/containers/jss/three-tier-web-app-todo-api:v0.0.1
# Layers' sha256 hashes should be identical

docker inspect gcr.io/sic-container-repo/todo-api-postgres
docker inspect  us-docker.pkg.dev/google-samples/containers/jss/three-tier-web-app-api-postgres:v0.0.1
# Layers' sha256 hashes should be identical
```
The use of the `docker inspect` command is suggested in this [StackOverflow post](https://stackoverflow.com/a/46322160).