### PR TITLE
fix: Test the specific set of roles used in Cloud console

### DIFF
--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -16,7 +16,18 @@
 
 locals {
   int_required_roles = [
-    "roles/owner"
+    "roles/artifactregistry.admin",
+    "roles/cloudsql.admin",
+    "roles/compute.networkAdmin",
+    "roles/iam.serviceAccountAdmin",
+    "roles/iam.serviceAccountUser",
+    "roles/redis.admin",
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/run.admin",
+    "roles/servicenetworking.serviceAgent",
+    "roles/serviceusage.serviceUsageViewer",
+    "roles/serviceusage.serviceUsageAdmin",
+    "roles/vpcaccess.admin"
   ]
 }
 


### PR DESCRIPTION
* See go/three-tier-web-app-textproto-line-70
* We would ideally (in our GitHub integration test) test the exact set of roles that we use inside Cloud console.